### PR TITLE
docs: mention voms-proxy next to kerberos

### DIFF
--- a/docs/advanced-usage/access-control/index.md
+++ b/docs/advanced-usage/access-control/index.md
@@ -1,3 +1,4 @@
 # Access control
 
-- [Kerberos](access-control/kerberos) to access restricted resources
+- [Kerberos](kerberos) to access restricted resources
+- [VOMS-proxy](voms-proxy) to authenticate with a VOMS proxy certificate

--- a/docs/advanced-usage/index.md
+++ b/docs/advanced-usage/index.md
@@ -19,3 +19,4 @@
 **Access control**
 
 - [Kerberos](access-control/kerberos) to access restricted resources
+- [VOMS-proxy](access-control/voms-proxy) to authenticate with a VOMS proxy certificate


### PR DESCRIPTION
Mention voms-proxy field in `Advanced usage` as well as `Access controll` next to Kerberos mention.