### PR TITLE
deploying-locally: simplification of instructions

### DIFF
--- a/docs/development/deploying-locally/index.md
+++ b/docs/development/deploying-locally/index.md
@@ -23,7 +23,6 @@ $ sh prefetch-images.sh
 $ helm repo add reanahub https://reanahub.github.io/reana
 $ helm repo update
 $ helm install reana reanahub/reana --namespace reana --create-namespace --wait
-$ kubectl -n reana get pods  # wait for pods to be in Running state
 ```
 
 **3.** Create REANA admin user:


### PR DESCRIPTION
Simplifies researcher-oriented installation instructions following on
the prefetching of Docker images. (It is no longer necessary to wait
for pods to be in Running state before proceeding.)