### PR TITLE
Add pip upgrade command to installation instructions

### DIFF
--- a/docs/getting-started/first-example/index.md
+++ b/docs/getting-started/first-example/index.md
@@ -18,6 +18,8 @@ Alternatively, you can install it via [pip](https://pip.pypa.io/en/stable/), ide
 $ # create new virtual environment
 $ virtualenv ~/.virtualenvs/reana
 $ source ~/.virtualenvs/reana/bin/activate
+$ # upgrade pip
+$ pip install --upgrade pip
 $ # install reana-client
 $ pip install reana-client
 ```


### PR DESCRIPTION
Without a fairly recent `pip` version, installation of `reana-client` will fail:

```
  Downloading https://files.pythonhosted.org/packages/e5/b9/6cf086d8aeda6ba04abc46da724818d48578398578ec64aa39bb7bb05997/uri_template-1.1.0-py3-none-any.whl
Collecting isoduration; extra == "format" (from jsonschema[format]>=3.0.1->reana-commons<0.8.0,>=0.7.5->reana-client)
  Could not find a version that satisfies the requirement isoduration; extra == "format" (from jsonschema[format]>=3.0.1->reana-commons<0.8.0,>=0.7.5->reana-client) (from versions: )
No matching distribution found for isoduration; extra == "format" (from jsonschema[format]>=3.0.1->reana-commons<0.8.0,>=0.7.5->reana-client)
You are using pip version 10.0.1, however version 21.3.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

Upgrading `pip` before attempting to install `reana-client` fixes this for both MacOS with python 3.6.6 and LXPLUS python 3.6.8 (system). This is in line with the existing tests that also upgrade `pip` as a first step.