### PR TITLE
docs: fix advanced usage index links

### DIFF
--- a/docs/advanced-usage/code-repositories/index.md
+++ b/docs/advanced-usage/code-repositories/index.md
@@ -1,4 +1,4 @@
 # Code repositories
 
-- [CVMFS](code-repositories/cvmfs) to integrate with CVMFS repositories
-- [GitLab](code-repositories/gitlab) to integrate with GitLab repositories
+- [CVMFS](cvmfs) to integrate with CVMFS repositories
+- [GitLab](gitlab) to integrate with GitLab repositories

--- a/docs/advanced-usage/index.md
+++ b/docs/advanced-usage/index.md
@@ -9,6 +9,7 @@
 **Storage backends**
 
 - [EOS](storage-backends/eos) for reading from and publishing on EOS object storage system
+- [NFS](storage-backends/nfs) for deploying NFS network file system
 - [Shared storage](storage-backends/shared-storage) for sharing results between workflow steps
 
 **Code repositories**

--- a/docs/advanced-usage/storage-backends/index.md
+++ b/docs/advanced-usage/storage-backends/index.md
@@ -1,4 +1,5 @@
 # Storage backends
 
-- [EOS](storage-backends/eos) for reading from and publishing on EOS object storage system
-- [Shared storage](storage-backends/shared-storage) for sharing results between workflow steps
+- [EOS](eos) for reading from and publishing on EOS object storage system
+- [NFS](nfs) for deploying NFS network file system
+- [Shared storage](shared-storage) for sharing results between workflow steps


### PR DESCRIPTION
Noticed that some of the links in `Advanced usage` section are broken:
- https://docs.reana.io/advanced-usage/storage-backends/ 
  - `NFS` description is not included in the index page
  - `EOS` and `Shared storage` links in the index page are broken

- https://docs.reana.io/advanced-usage/code-repositories/
  - links in the index page are broken

- https://docs.reana.io/advanced-usage/
  - `NFS` description is not included in the index page