### PR TITLE
ci: add `gitlab-ci.yml` to build mkdocs site

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,3 @@
+include:
+  - project: 'authoring/documentation/mkdocs-ci'
+    file: 'mkdocs-gitlab-pages.gitlab-ci.yml'


### PR DESCRIPTION
Needed to migrate site from OpenShift 3 to OKD4 at CERN

https://how-to.docs.cern.ch/gitlabpagessite/migration/configure_repo/