### PR TITLE
docs: improve copy-to-clipboard

### DIFF
--- a/docs/administration/deployment/deploying-locally/index.md
+++ b/docs/administration/deployment/deploying-locally/index.md
@@ -7,7 +7,7 @@ you can proceed as follows.
 
 **1.** Install `docker`, `kubectl`, `kind`, and `helm` dependencies:
 
-```console
+```{ .console .copy-to-clipboard }
 $ firefox https://docs.docker.com/engine/install/
 $ firefox https://kubernetes.io/docs/tasks/tools/install-kubectl/
 $ firefox https://kind.sigs.k8s.io/docs/user/quick-start/
@@ -16,7 +16,7 @@ $ firefox https://helm.sh/docs/intro/install/
 
 **2.** Deploy REANA cluster:
 
-```console
+```{ .console .copy-to-clipboard }
 $ wget https://raw.githubusercontent.com/reanahub/reana/maint-0.8/etc/kind-localhost-30443.yaml
 $ kind create cluster --config kind-localhost-30443.yaml
 $ wget https://raw.githubusercontent.com/reanahub/reana/maint-0.8/scripts/prefetch-images.sh
@@ -28,14 +28,14 @@ $ helm install reana reanahub/reana --namespace reana --create-namespace --wait
 
 **3.** Create REANA admin user:
 
-```console
+```{ .console .copy-to-clipboard }
 $ wget https://raw.githubusercontent.com/reanahub/reana/maint-0.8/scripts/create-admin-user.sh
 $ sh create-admin-user.sh reana reana john.doe@example.org mysecretpassword
 ```
 
 **4.** Log into your REANA instance:
 
-```console
+```{ .console .copy-to-clipboard }
 $ firefox https://localhost:30443
 ```
 

--- a/docs/administration/deployment/upgrading-db/index.md
+++ b/docs/administration/deployment/upgrading-db/index.md
@@ -20,7 +20,7 @@ upgrade.
 After you upgrade REANA by running `helm upgrade` successfully, run the
 following command:
 
-```console
+```{ .console .copy-to-clipboard }
 $ kubectl exec -i -t deployment/reana-server -c rest-api -- reana-db alembic upgrade
 ```
 

--- a/docs/administration/management/managing-users/index.md
+++ b/docs/administration/management/managing-users/index.md
@@ -4,7 +4,7 @@
 
 To manage users you will need to obtain administration credentials:
 
-```console
+```{ .console .copy-to-clipboard }
 $ export KUBECONFIG=~/mycluster/config
 $ export REANA_ACCESS_TOKEN=$(kubectl get secret reana-admin-access-token -o json | jq -r '.data | map_values(@base64d) | .ADMIN_ACCESS_TOKEN')
 ```
@@ -49,13 +49,13 @@ User token c0fa47fa00ae4013a13fd7n (new.web.user@example.org) was successfully r
 
 ### Export users
 
-```console
+```{ .console .copy-to-clipboard }
 $ kubectl exec -i -t deployment/reana-server -- flask reana-admin user-export --admin-access-token $REANA_ACCESS_TOKEN > myusers.csv
 ```
 
 ### Import users
 
-```console
+```{ .console .copy-to-clipboard }
 $ # put myusers.csv onto the node in the /var/reana directory and run:
 $ kubectl exec -i -t deployment/reana-server -- flask reana-admin user-import --admin-access-token $REANA_ACCESS_TOKEN --file /var/reana/myusers.csv
 ```

--- a/docs/advanced-usage/access-control/kerberos/index.md
+++ b/docs/advanced-usage/access-control/kerberos/index.md
@@ -8,7 +8,7 @@ EOS you could use Kerberos authentication.
 First, generate a Kerberos keytab file for passwordless authentication.
 
 ```console
-# login to lxplus and generate keytab file
+$ # login to lxplus and generate keytab file
 $ ssh johndoe@lxplus.cern.ch
 $ ktutil
 ktutil:  add_entry -password -p johndoe@CERN.CH -k 1 -e aes256-cts-hmac-sha1-96
@@ -18,7 +18,7 @@ Password for johndoe@CERN.CH:
 ktutil:  write_kt .keytab
 ktutil:  exit
 
-# Let's test generated keytab file by trying to generate Kerberos ticket
+$ # Let's test generated keytab file by trying to generate Kerberos ticket
 $ scp johndoe@lxplus.cern.ch:~/.keytab .
 $ kinit -kt ~/.keytab johndoe@CERN.CH
 $ klist
@@ -39,7 +39,7 @@ Valid starting       Expires              Service principal
 Once you have a working keytab file, you need to upload your CERN username
 and keytab secrets to REANA:
 
-```console
+```{ .console .copy-to-clipboard }
 $ reana-client secrets-add --env CERN_USER=johndoe \
                            --env CERN_KEYTAB=.keytab \
                            --file ~/.keytab

--- a/docs/advanced-usage/access-control/voms-proxy/index.md
+++ b/docs/advanced-usage/access-control/voms-proxy/index.md
@@ -9,15 +9,15 @@ If you do not already have a user certificate create one at [ca.cern.ch/ca](http
 Before moving to REANA, check that your credentials are in order.
 
 ```console
-# Login to lxplus
+$ # Login to lxplus
 $ ssh johndoe@lxplus.cern.ch
 
-# Make sure userkey.pem is read/write only by the owner
+$ # Make sure userkey.pem is read/write only by the owner
 $ ls -l ~/.globus
 -rw-r--r--. usercert.pem
 -r--------. userkey.pem
 
-# Let us create a proxy certificate with the VO cms
+$ # Let us create a proxy certificate with the VO cms
 $ voms-proxy-init --voms cms
 Enter GRID pass phrase for this identity:
 
@@ -41,7 +41,7 @@ bXlncmlkcGFzc3BocmFzZQo=
 
 Upload these three secrets to REANA. In addition REANA needs information about your VO. This is communicated by the environment variable `VONAME` and can also be added to the secrets:
 
-```console
+```{ .console .copy-to-clipboard }
 $ reana-client secrets-add --file userkey.pem \
                            --file usercert.pem \
                            --env VOMSPROXY_PASS=bXlncmlkcGFzc3BocmFzZQo= \

--- a/docs/advanced-usage/containers/docker/index.md
+++ b/docs/advanced-usage/containers/docker/index.md
@@ -18,7 +18,7 @@ This is usually the case when your code needs to be compiled, for example C++ an
 
 If you need to create your own environment, this can be achieved by means of providing a particular `Dockerfile`:
 
-```Dockerfile
+```{ .Dockerfile .copy-to-clipboard }
 # Start from the Python 2.7 base image:
 FROM python:2.7
 
@@ -38,13 +38,13 @@ WORKDIR /code
 
 You can build this customised analysis environment image and give it some name, for example `johndoe/myenv`:
 
-```console
+```{ .console .copy-to-clipboard }
 $ docker build -f environment/myenv/Dockerfile -t johndoe/myenv .
 ```
 
 and push the created image to the DockerHub image registry:
 
-```console
+```{ .console .copy-to-clipboard }
 $ docker push johndoe/myenv
 ```
 
@@ -61,7 +61,7 @@ This will ensure the writable access to workspace directories managed by the REA
 
 For example, you can create the user `johndoe` with `UID=501` and add the user to `GID=0` by adding the following commands at the end of the previous `Dockerfile`:
 
-```Dockerfile
+```{ .Dockerfile .copy-to-clipboard }
 # Setup user and permissions
 RUN adduser johndoe -u 501 --disabled-password --gecos ""
 RUN usermod -a -G 0 johndoe

--- a/docs/advanced-usage/storage-backends/nfs/index.md
+++ b/docs/advanced-usage/storage-backends/nfs/index.md
@@ -14,13 +14,13 @@ storageClass:
 
 - **2.** Install the NFS Server Provisioner:
 
-```console
+```{ .console .copy-to-clipboard }
 $ helm install reana-dev-storage stable/nfs-server-provisioner \
                -f nfs-provisioner-values.yaml
 ```
 
 - **3.** Install REANA with NFS support:
 
-```console
+```{ .console .copy-to-clipboard }
 $ helm install reana reanahub/reana --set shared_storage.backend=nfs
 ```

--- a/docs/getting-started/first-example/index.md
+++ b/docs/getting-started/first-example/index.md
@@ -2,19 +2,19 @@
 
 First, obtain your new REANA command-line access token. For example, at CERN, do:
 
-```console
+```{ .console .copy-to-clipboard }
 $ firefox https://reana.cern.ch
 ```
 
 Second, install and activate the REANA command-line client [reana-client](https://pypi.org/project/reana-client/). For example, at CERN, login to LXPLUS and activate it as follows:
 
-```console
+```{ .console .copy-to-clipboard }
 $ source /afs/cern.ch/user/r/reana/public/reana/bin/activate
 ```
 
 Alternatively, you can install it via [pip](https://pip.pypa.io/en/stable/), ideally in a new virtual environment:
 
-```console
+```{ .console .copy-to-clipboard }
 $ # create new virtual environment
 $ virtualenv ~/.virtualenvs/reana
 $ source ~/.virtualenvs/reana/bin/activate
@@ -26,7 +26,7 @@ $ pip install reana-client
 
 Third, set REANA environment variables for the client (using the access token obtained in the first step) and test your connection:
 
-```console
+```{ .console .copy-to-clipboard }
 $ export REANA_SERVER_URL=https://reana.cern.ch
 $ export REANA_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxx
 $ reana-client ping

--- a/docs/running-workflows/what-is-workflow/index.md
+++ b/docs/running-workflows/what-is-workflow/index.md
@@ -6,7 +6,7 @@ Workflows describe which computational steps were taken to run an analysis.
 
 Let us assume that our analysis is run in two stages, firstly a data filtering stage and secondly a data plotting stage. A hypothetical example:
 
-```console
+```{ .console .copy-to-clipboard }
 $ python ./code/mycode.py \
     < ./data/mydata.csv > ./workspace/mydata.tmp
 $ python ./code/mycode.py --plot myparameter=myvalue \
@@ -15,13 +15,13 @@ $ python ./code/mycode.py --plot myparameter=myvalue \
 
 Note how we call a given sequence of commands to produce our desired output plots. In order to capture this sequence of commands in a “runnable” or “actionable” manner, we can write a short shell script `run.sh` and make it parametrisable:
 
-```console
+```{ .console .copy-to-clipboard }
 $ ./run.sh --myparameter myvalue
 ```
 
 In this case you will want to use the [Serial](../supported-systems/serial) workflow engine of REANA. The engine permits to express the workflow as a sequence of commands:
 
-```console
+```text
     START
      |
      |
@@ -52,7 +52,7 @@ For advanced workflow needs we may want to run certain commands in parallel in a
 
 The workflow systems enable to express the computational steps in the form of [Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph) permitting advanced computational scenarios.
 
-```console
+```text
               START
                |
                |

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -153,3 +153,14 @@ html .md-footer-meta .md-footer-meta__inner a {
 .md-typeset .admonition.note .admonition-title::before {
     color: #c8aeae;
 }
+
+/* show the copy-to-clipboard button only if .copy-to-clipboard is specified */
+.codehilite:not(.copy-to-clipboard) .md-clipboard {
+    display: none;
+}
+
+/* do not copy the terminal prompt `$` */
+pre > code > .gp {
+    -webkit-user-select: none;
+    user-select: none;
+}


### PR DESCRIPTION
- Do not copy the terminal prompt `$` when copying console snippets
- Keep the copy-to-clipboard button only for some specific snippets

Closes #120