### PR TITLE
voms-proxy: info about job environment images

### DIFF
--- a/docs/advanced-usage/access-control/voms-proxy/index.md
+++ b/docs/advanced-usage/access-control/voms-proxy/index.md
@@ -1,121 +1,228 @@
-# VOMS-proxy
+# VOMS proxy
 
-If your workflow needs special permissions that your Virtual Organization (VO) entitles you to, you can use VOMS authentication. VOMS (Virtual Organization Membership Service) provides information on the user's relationship with their VO. VOs administer users and grant them permissions according to their group, role and capability. At CERN the different experiments such as ALICE, ATLAS, CMS and LHCb all have their own VO. Being part of a VO can give you access to globally distributed data analysis infrastructure.
+## About VOMS
 
-If you do not already have a user certificate create one at [ca.cern.ch/ca](https://ca.cern.ch/ca/).
+The Virtual Organization Membership Service
+([VOMS](https://italiangrid.github.io/voms/index.html)) is at the core of the
+authorisation stack of the Worldwide LHC Computing Grid
+([WLCG](https://wlcg.web.cern.ch/)).
+
+VOMS provides information about the relationship between researchers and their
+Virtual Organizations (VOs). The VOs manage users and grant them permissions
+according to their groups and roles. At CERN, all the various experimental
+collaborations such as ALICE, ATLAS, CMS and LHCb have their own VO. Being part
+of a VO can give you access to the globally distributed data analysis
+infrastructure of the collaboration.
+
+If your workflow needs special data access rights using permissions granted by
+your Virtual Organization, you can use the VOMS proxy authentication technique
+with your REANA workflows as described in detail below.
 
 ## Testing your credentials
 
-Before moving to REANA, check that your credentials are in order.
+If you do not have a user certificate yet, please create one at
+[ca.cern.ch/ca](https://ca.cern.ch/ca/) and generate your `usercert.pem` and
+`userkey.pem` following [voms-proxy-init
+documentation](https://ca.cern.ch/ca/Help/?kbid=024010).
+
+Please check that your credentials are in order by logging in to LXPLUS:
 
 ```console
-$ # Login to lxplus
 $ ssh johndoe@lxplus.cern.ch
+```
 
-$ # Make sure userkey.pem is read/write only by the owner
+Make sure that your `userkey.pem` is read-write accessible only by you as the
+file owner:
+
+```console
 $ ls -l ~/.globus
--rw-r--r--. usercert.pem
--r--------. userkey.pem
+-rw-------. usercert.pem
+-rw-------. userkey.pem
+```
 
-$ # Let us create a proxy certificate with the VO cms
+Try to create a VOMS proxy certificate for your Virtual Organization:
+
+```console
 $ voms-proxy-init --voms cms
 Enter GRID pass phrase for this identity:
 
-Contacting voms2.cern.ch:15002 [/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch] "cms"...
-Remote VOMS server contacted succesfully.
+Contacting voms2.cern.ch:15002 [/DC=ch/DC=cern/OU=computers/CN=voms2.cern.ch]...
 
+Remote VOMS server contacted succesfully.
 
 Created proxy in /tmp/x509up_u131816.
 
 Your proxy is valid until Wed Apr 01 00:43:08 CEST 2020
 ```
 
+If these steps succeed, you are ready to use the VOMS proxy authentication
+technique with REANA.
+
 ## Uploading secrets
 
-To create the proxy certificate REANA needs access to your user certificate `usercert.pem`, encrypted private key `userkey.pem` and GRID pass phrase encoded in Base64. To encode your pass phrase exchange `mygridpassphrase` for your GRID pass phrase and perform:
+In order to create the proxy certificate for your workflow jobs, REANA would
+need to access your (i) user certificate `usercert.pem`, (ii) encrypted private
+key `userkey.pem`, and (iii) the Grid passphrase encoded using the base64
+encoding. For example, if your Grid passphrase is `mygridpassphrase`, you
+would generate the corresponding base64-encoded value as follows:
 
 ```console
-$ echo 'mygridpassphrase' | base64
-bXlncmlkcGFzc3BocmFzZQo=
+$ echo -n 'mygridpassphrase' | base64
+bXlncmlkcGFzc3BocmFzZQ==
 ```
 
-Upload these three secrets to REANA. In addition REANA needs information about your VO. This is communicated by the environment variable `VONAME` and can also be added to the secrets:
+Thusly encoded passphrase will be expected as the `VOMSPROXY_PASS` environment
+variable's value.
 
-```{ .console .copy-to-clipboard }
+Finally, REANA needs to know also (iv) which VO you would like to use, such as
+"atlas" or "cms". This should be specified in the environment variable
+`VONAME`.
+
+These four necessary secrets can be uploaded to REANA as follows:
+
+```console
 $ reana-client secrets-add --file userkey.pem \
                            --file usercert.pem \
-                           --env VOMSPROXY_PASS=bXlncmlkcGFzc3BocmFzZQo= \
+                           --env VOMSPROXY_PASS=bXlncmlkcGFzc3BocmFzZQ== \
                            --env VONAME=cms
 ```
 
-## Setting voms-proxy requirement
+## Configuring your workflows
 
-Set `voms_proxy: true` for the steps that need a proxy certificate in the workflow specification.
-Please note that step's docker image (e.g `environment: 'reanahub/reana-auth-vomsproxy'`)
-should have the VOMS client installed for the command `voms-proxy-info` to work.
+You are now ready to declare that some steps of your workflow need VOMS proxy
+to access restricted data. This can be achieved by setting the workflow hint
+called `voms_proxy` for those steps. The examples below show how to specify
+this hint for your CWL, Serial, Snakemake and Yadage workflows.
 
-Serial example:
+CWL workflow example:
+
+```yaml hl_lines="3 4 5"
+steps:
+  first:
+    hints:
+      reana:
+        voms_proxy: true
+    run: my_xrdcp_step.tool
+```
+
+Serial workflow example:
 
 ```yaml hl_lines="6"
 workflow:
   type: serial
   specification:
     steps:
-      - environment: "reanahub/reana-auth-vomsproxy"
+      - environment: johndoe/myanalysisenvironment:1.0
         voms_proxy: true
         commands:
-          - voms-proxy-info
+          - xrdcp root://example.org//mydata.root .
 ```
 
-CWL example:
+Snakemake example:
 
-```yaml hl_lines="5"
-steps:
-  first:
-    hints:
-      reana:
-        voms_proxy: true
-    run: helloworld.tool
-    in:
-      helloworld: helloworld
-
-      inputfile: inputfile
-      sleeptime: sleeptime
-      outputfile: outputfile
-    out: [result]
+```yaml hl_lines="4 5"
+rule mystep:
+  container:
+    "docker://johndoe/myanalysisenvironment:1.0"
+  resources:
+    voms_proxy=True
+  shell:
+    "xrdcp root://example.org//mydata.root ."
 ```
 
 Yadage example:
 
-```yaml hl_lines="14"
+```yaml hl_lines="13 14"
 step:
   process:
     process_type: "string-interpolated-cmd"
-    cmd: 'python "{helloworld}" --sleeptime {sleeptime} --inputfile "{inputfile}" --outputfile "{outputfile}"'
+    cmd: 'xrdcp root://example.org//mydata.root .'
   publisher:
     publisher_type: "frompar-pub"
     outputmap:
       outputfile: outputfile
   environment:
     environment_type: "docker-encapsulated"
-    image: "python"
-    imagetag: "2.7-slim"
+    image: "johndoe/myanalysisenvironment"
+    imagetag: "1.0"
     resources:
       - voms_proxy: true
 ```
 
-Snakemake example:
+The `voms_proxy` workflow hint is fully sufficient to instruct REANA to set up
+the VOMS proxy authentication for your jobs. You don't have to modify the logic
+of your workflow steps in any other way besides providing the above one-line
+workflow hint declarations.
 
-```yaml hl_lines="10"
-rule helloworld:
-  input: 
-    helloworld=config["helloworld"],
-    inputfile=config["inputfile"],
-  params: 
-    sleeptime=config["sleeptime"]
-  output: 
-    "results/greetings.txt"
-  resources:
-    voms_proxy: true
-  container: "docker://python:2.7-slim"
+## Creating your job environment images
+
+In the above examples, we have used `johndoe/myanalysisenvironment:1.0` as an
+example of the job environment container image that would be used at runtime to
+execute the workflow step that is accessing some VO restricted resource. When
+REANA will orchestrate the execution of this job, it will automatically create
+a sidecar container that will perform the necessary VOMS proxy authentication
+beforehand, using the secrets you uploaded. In some cases, this may already be
+sufficient for your VO restricted resource usage needs.
+
+However, if you would like to access restricted data located on a remote Grid
+site, your job is expected to have local access to the Grid site certificates
+for the authentication verification to work. It is the responsibility of your
+job container image to provide `xrdcp` tools and any remote Grid site
+certificates that may be needed for the execution of your workflow. REANA's
+VOMS proxy sidecar container only takes care of establishing the VOMS proxy
+authentication. Therefore, you may need to check whether your job images
+contain all the necessary tools to work with remote Grid sites.
+
+For example, let us assume that you are an ATLAS physicist who uses
+`atlas/analysisbase:21.2.130` as the base job environment image for your
+analysis. This image uses a special "atlas" user and is based on the CentOS
+Linux 7 distribution:
+
+```console
+$ docker run -i -t --rm atlas/analysisbase:21.2.130 /usr/bin/id
+uid=1000(atlas) gid=1000(atlas) groups=1000(atlas),10(wheel)
+
+$ docker run -i -t --rm atlas/analysisbase:21.2.130 /bin/bash -c 'cat /etc/redhat-release'
+CentOS Linux release 7.7.1908 (Core)
 ```
+
+However, the image does not contain any Grid certificates. For example, the
+German Grid sites certificates are missing:
+
+```console
+$ docker run -i -t --rm atlas/analysisbase:21.2.130 /bin/bash -c 'ls -l /etc/grid-security/certificates/GermanGrid.pem'
+ls: cannot access /etc/grid-security/certificates/GermanGrid.pem: No such file or directory
+```
+
+This may lead to problems accessing German Grid sites in your workflows, even
+if the VOMS proxy authentication worked well. If you would like to access
+remote data located on a German grid site, then you should enrich your job
+environment image by amending `Dockerfile` as follows:
+
+```console
+$ cat Dockerfile
+FROM atlas/analysisbase:21.2.130
+USER root
+RUN curl -o /etc/yum.repos.d/EGI-trustanchors.repo https://repository.egi.eu/sw/production/cas/1/current/repo-files/EGI-trustanchors.repo && \
+    yum -y install ca-certificates ca-policy-egi-core wlcg-voms-atlas && \
+    yum -y clean all
+USER atlas
+$ docker build -t johndoe/myanalysisenvironment:1.0 .
+```
+
+Installing packages such as `ca-policy-egi-core` and `wlcg-voms-atlas` will
+make sure that all the necessary Grid certificates and tools are present in the
+environment image during its runtime execution.
+
+We can verify the produced image as follows:
+
+```console
+$ docker run -i -t --rm johndoe/myanalysisenvironment:1.0 /bin/bash -c 'ls -l /etc/grid-security/certificates/GermanGrid.pem'
+-rw-r--r--. 1 root root 1407 Mar 30 11:18 /etc/grid-security/certificates/GermanGrid.pem
+
+$ docker run -i -t --rm johndoe/myanalysisenvironment:1.0 /bin/bash -c 'rpm -qa | grep ca_German'
+ca_GermanGrid-1.116-1.noarch
+```
+
+Now the workflow steps using the `voms_proxy` hint and accessing remote restricted
+data from German Grid sites should succeed.


### PR DESCRIPTION
Adds information about how to create job environment images so that they
would include all the necessary Grid certificates.

Refactors the other page content to improve examples and verbiage.