### PR TITLE
global: add missing `--admin-access-token` to `reana-admin` examples

### DIFF
--- a/docs/administration/configuration/configuring-interactive-sessions/index.md
+++ b/docs/administration/configuration/configuring-interactive-sessions/index.md
@@ -34,7 +34,7 @@ interactive_sessions:
     For example, to close any interactive session that has been inactive since 30 days, you would run:
 
     ```console
-    $ kubectl exec -i -t deployment/reana-server -- flask reana-admin interactive-session-cleanup --days 30
+    $ kubectl exec -i -t deployment/reana-server -- flask reana-admin interactive-session-cleanup --days 30 --admin-access-token $REANA_ACCESS_TOKEN
     Interactive session 'reana-run-session-69d590c3-ce47-4ae1-8719-bf8952627b37-c7djf67l' has been closed.
     Interactive session 'reana-run-session-69d590c3-ce47-4ae1-8719-bf8952627b37-c7djf67l' was updated 2 days ago. Leaving opened.
     ```

--- a/docs/administration/configuration/configuring-user-quotas/index.md
+++ b/docs/administration/configuration/configuring-user-quotas/index.md
@@ -61,7 +61,7 @@ $ kubectl exec -i -t deployment/reana-server -- /bin/bash
 You can now set a custom quota limit to selected users:
 
 ```console
-# flask reana-admin quota-set -e john.doe@example.org -r disk -l 250000
+# flask reana-admin quota-set -e john.doe@example.org -r disk -l 250000 --admin-access-token $REANA_ACCESS_TOKEN
 Quota limit 250000 for 'disk (shared storage)' successfully set to users ('john.doe@example.org',).
 ```
 


### PR DESCRIPTION
Closes reanahub/reana-server#489
