### PR TITLE
docs: add list --shared arguments

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,6 +6,7 @@ The list of contributors in alphabetical order:
 - [Agisilaos Kounelis](https://orcid.org/0000-0001-9312-3189)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
 - [Clemens Lange](https://orcid.org/0000-0002-3632-3157)
+- [Daan Rosendal](https://orcid.org/0000-0002-3447-9000)
 - [Diego Rodriguez](https://orcid.org/0000-0003-0649-2002)
 - [Domenic Gosein](https://orcid.org/0000-0002-1546-0435)
 - [Elena Gazzarrini](https://orcid.org/0000-0001-5772-5166)

--- a/docs/reference/reana-client-cli-api/index.md
+++ b/docs/reference/reana-client-cli-api/index.md
@@ -40,6 +40,7 @@ Workflow execution commands:
 Workflow sharing commands:
   share-add     Share a workflow with other users (read-only).
   share-remove  Unshare a workflow.
+  share-status  Show with whom a workflow is shared.
 
 Workspace interactive commands:
   close  Close an interactive session.
@@ -318,6 +319,17 @@ Example:
 
 <!-- markdownlint-disable no-bare-urls -->
 $ reana-client share-remove -w myanalysis.42 --user bob@example.org
+
+### share-status
+
+Show with whom a workflow is shared.
+
+The `share-status` command allows for checking with whom a workflow is
+shared.
+
+Example:
+
+$ reana-client share-status -w myanalysis.42
 
 ## Workspace interactive commands
 

--- a/docs/reference/reana-client-cli-api/index.md
+++ b/docs/reference/reana-client-cli-api/index.md
@@ -37,6 +37,9 @@ Workflow execution commands:
   stop      Stop a running workflow.
   validate  Validate workflow specification file.
 
+Workflow sharing commands:
+  share-add  Share a workflow with other users (read-only).
+
 Workspace interactive commands:
   close  Close an interactive session.
   open   Open an interactive session inside the workspace.
@@ -285,6 +288,23 @@ Examples:
      $ reana-client run -w myanalysis-test-small -p myparam=mysmallvalue
 
      $ reana-client run -w myanalysis-test-big -p myparam=mybigvalue
+
+## Workflow sharing commands
+
+### share-add
+
+Share a workflow with other users (read-only).
+
+The `share-add` command allows sharing a workflow with other users. The
+users will be able to view the workflow but not modify it.
+
+Examples:
+
+<!-- markdownlint-disable no-bare-urls -->
+$ reana-client share-add -w myanalysis.42 --user bob@cern.ch
+
+<!-- markdownlint-disable no-bare-urls -->
+$ reana-client share-add -w myanalysis.42 --user bob@cern.ch --user cecile@cern.ch --message "Please review my analysis" --valid-until 2024-12-31
 
 ## Workspace interactive commands
 

--- a/docs/reference/reana-client-cli-api/index.md
+++ b/docs/reference/reana-client-cli-api/index.md
@@ -38,7 +38,8 @@ Workflow execution commands:
   validate  Validate workflow specification file.
 
 Workflow sharing commands:
-  share-add  Share a workflow with other users (read-only).
+  share-add     Share a workflow with other users (read-only).
+  share-remove  Unshare a workflow.
 
 Workspace interactive commands:
   close  Close an interactive session.
@@ -305,6 +306,18 @@ $ reana-client share-add -w myanalysis.42 --user bob@cern.ch
 
 <!-- markdownlint-disable no-bare-urls -->
 $ reana-client share-add -w myanalysis.42 --user bob@cern.ch --user cecile@cern.ch --message "Please review my analysis" --valid-until 2024-12-31
+
+### share-remove
+
+Unshare a workflow.
+
+The `share-remove` command allows for unsharing a workflow. The workflow
+will no longer be visible to the users with whom it was shared.
+
+Example:
+
+<!-- markdownlint-disable no-bare-urls -->
+$ reana-client share-remove -w myanalysis.42 --user bob@example.org
 
 ## Workspace interactive commands
 

--- a/docs/reference/reana-client-cli-api/index.md
+++ b/docs/reference/reana-client-cli-api/index.md
@@ -126,15 +126,33 @@ List all workflows and sessions.
 The ``list`` command lists workflows and sessions. By default, the list of
 workflows is returned. If you would like to see the list of your open
 interactive sessions, you need to pass the ``--sessions`` command-line
-option.
+option. If you would like to see the list of all workflows, including those
+shared with you, you need to pass the ``--shared`` command-line option.
 
-Example:
+Along with specific user emails, you can pass the following special values
+to the ``--shared-by`` and ``--shared-with`` command-line options:
+
+     - ``--shared-by anybody``: list workflows shared with you by anybody.
+
+     - ``--shared-with anybody``: list your shared workflows exclusively.
+
+     - ``--shared-with nobody``: list your unshared workflows exclusively.
+
+     - ``--shared-with bob@cern.ch``: list workflows shared with bob@cern.ch
+
+Examples:
 
      $ reana-client list --all
 
      $ reana-client list --sessions
 
      $ reana-client list --verbose --bytes
+
+     $ reana-client list --shared
+
+     $ reana-client list --shared-by bob@cern.ch
+
+     $ reana-client list --shared-with anybody
 
 ### create
 
@@ -302,11 +320,9 @@ users will be able to view the workflow but not modify it.
 
 Examples:
 
-<!-- markdownlint-disable no-bare-urls -->
-$ reana-client share-add -w myanalysis.42 --user bob@cern.ch
+     $ reana-client share-add -w myanalysis.42 --user bob@example.org
 
-<!-- markdownlint-disable no-bare-urls -->
-$ reana-client share-add -w myanalysis.42 --user bob@cern.ch --user cecile@cern.ch --message "Please review my analysis" --valid-until 2024-12-31
+     $ reana-client share-add -w myanalysis.42 --user bob@example.org --user cecile@example.org --message "Please review my analysis" --valid-until 2025-12-31
 
 ### share-remove
 
@@ -317,8 +333,7 @@ will no longer be visible to the users with whom it was shared.
 
 Example:
 
-<!-- markdownlint-disable no-bare-urls -->
-$ reana-client share-remove -w myanalysis.42 --user bob@example.org
+    $ reana-client share-remove -w myanalysis.42 --user bob@example.org
 
 ### share-status
 
@@ -329,7 +344,7 @@ shared.
 
 Example:
 
-$ reana-client share-status -w myanalysis.42
+    $ reana-client share-status -w myanalysis.42
 
 ## Workspace interactive commands
 


### PR DESCRIPTION
Adds extra docs for `list` command to the docs for new sharing related
arguments.

Closes reanahub/reana-client#687
