### PR TITLE
ci(commitlint): addition of commit message linter

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,21 @@
+rules:
+  body-case: [2, always, sentence-case]
+  body-full-stop: [2, always]
+  body-leading-blank: [2, always]
+  body-max-line-length: [2, always, 72]
+  footer-leading-blank: [2, always]
+  footer-max-line-length: [2, always, 72]
+  header-max-length: [2, always, 72]
+  scope-case: [2, always, lower-case]
+  subject-case:
+    - 2
+    - never
+    - [pascal-case, sentence-case, start-case, upper-case]
+  subject-empty: [2, never]
+  subject-full-stop: [2, never, "."]
+  type-case: [2, always, lower-case]
+  type-empty: [2, never]
+  type-enum:
+    - 2
+    - always
+    - [build, chore, ci, docs, feat, fix, perf, refactor, style, test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +9,32 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  lint-commitlint:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Install commitlint
+        run: |
+          npm install conventional-changelog-conventionalcommits
+          npm install commitlint@latest
+
+      - name: Check commit message compliance of the recently pushed commit
+        if: github.event_name == 'push'
+        run: |
+          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+
+      - name: Check commit message compliance of the pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} ${{ github.event.pull_request.head.sha }}
+
   lint-shellcheck:
     runs-on: ubuntu-20.04
     steps:
@@ -18,7 +44,7 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellscript
+          ./run-tests.sh --check-shellcheck
 
   build-docs:
     runs-on: ubuntu-20.04

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019, 2020, 2021, 2022, 2023 REANA
+Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,19 +1,34 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-# Quit on errors
 set -o errexit
-
-# Quit on unbound symbols
 set -o nounset
 
-check_script () {
-    shellcheck run-tests.sh
+check_commitlint () {
+    from=${2:-master}
+    to=${3:-HEAD}
+    npx commitlint --from="$from" --to="$to"
+    found=0
+    while IFS= read -r line; do
+        if echo "$line" | grep -qP "\(\#[0-9]+\)$"; then
+            true
+        else
+            echo "✖   PR number missing in $line"
+            found=1
+        fi
+    done < <(git log "$from..$to" --format="%s")
+    if [ $found -gt 0 ]; then
+        exit 1
+    fi
+}
+
+check_shellcheck () {
+    find . -name "*.sh" -exec shellcheck {} \;
 }
 
 check_docstyle () {
@@ -27,17 +42,17 @@ build_docs () {
 }
 
 if [ $# -eq 0 ]; then
-    check_script
+    check_commitlint
+    check_shellcheck
     check_docstyle
     build_docs
 fi
 
-for arg in "$@"
-do
-    case $arg in
-        --check-shellscript) check_script;;
-        --check-docstyle) check_docstyle;;
-        --build-docs) build_docs;;
-        *)
-    esac
-done
+arg="$1"
+case $arg in
+    --check-commitlint) check_commitlint "$@";;
+    --check-shellcheck) check_shellcheck;;
+    --check-docstyle) check_docstyle;;
+    --build-docs) build_docs;;
+    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+esac


### PR DESCRIPTION
Adds commitlint to check the commit message style against agreed conventional commits configuration.

Changes script argument values to always use linter names (e.g. shellcheck).

Changes argument handling to allow only one checking action that can now accept further optional arguments.