### PR TITLE
docs(cli): fix `reana-client open` command documentation typo (#204)

### DIFF
--- a/docs/reference/reana-client-cli-api/index.md
+++ b/docs/reference/reana-client-cli-api/index.md
@@ -294,7 +294,7 @@ Open an interactive session inside the workspace.
 
 The ``open`` command allows to open interactive session processes on top of
 the workflow workspace, such as Jupyter notebooks. This is useful to
-quickly inspect and analyse the produced files while the workflow is stlil
+quickly inspect and analyse the produced files while the workflow is still
 running.
 
 Examples:


### PR DESCRIPTION
See reanahub/reana-client#716.