### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2024 CERN.
+# Copyright (C) 2020, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on: [push, pull_request]
 
@@ -28,12 +28,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -44,7 +44,7 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   build-docs:
     runs-on: ubuntu-24.04
@@ -75,7 +75,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Lint docs
-        run: ./run-tests.sh --check-docstyle
+        run: ./run-tests.sh --lint-docstyle
 
       - name: Build docs
         run: ./run-tests.sh --build-docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,21 @@ jobs:
 
       - name: Build docs
         run: ./run-tests.sh --build-docs
+
+lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2023, 2024, 2026 CERN.
+# Copyright (C) 2020, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +9,51 @@ name: ci
 on: [push, pull_request]
 
 jobs:
+  build-docs:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby 2.6
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Install project dependences
+        run: |
+          sudo apt-get update -y
+          gem install awesome_bot
+          pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Lint docs
+        run: ./run-tests.sh --lint-docstyle
+
+      - name: Build docs
+        run: ./run-tests.sh --build-docs
+
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:
@@ -46,47 +91,11 @@ jobs:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
-  build-docs:
+  lint-yamllint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up Ruby 2.6
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "2.6"
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-
-      - name: Install project dependences
-        run: |
-          sudo apt-get update -y
-          gem install awesome_bot
-          pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Lint docs
-        run: ./run-tests.sh --lint-docstyle
-
-      - name: Build docs
-        run: ./run-tests.sh --build-docs
-
-lint-yamllint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,33 +15,46 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Ruby 2.6
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "2.6"
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
 
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "18"
-
-      - name: Install project dependences
+      - name: Build docs
         run: |
-          sudo apt-get update -y
-          gem install awesome_bot
           pip install --upgrade pip
           pip install -r requirements.txt
+          ./run-tests.sh --docs-build
 
-      - name: Lint docs
-        run: ./run-tests.sh --lint-docstyle
+  lint-awesome-bot:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Build docs
-        run: ./run-tests.sh --build-docs
+      - name: Set up Ruby 2.6
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+
+      - name: Check links in documentation
+        run: |
+          gem install awesome_bot
+          ./run-tests.sh --lint-awesome-bot
+
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
 
   format-shfmt:
     runs-on: ubuntu-24.04

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,18 @@
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow code block style variations
+MD046: false
+# Allow long lines
+MD013: false
+# Allow emphasis as heading
+MD036: false
+# Allow trailing punctuation in headings
+MD026: false
+# Allow non-standard indentation in unordered lists
+MD007: false
+# Allow inline HTML
+MD033: false
+# Allow non-descriptive link text
+MD059: false
+# Allow flexible table column style
+MD060: false

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,9 +1,0 @@
-{
-  "commands-show-output": false,
-  "code-block-style": false,
-  "line-length": false,
-  "no-emphasis-as-heading": false,
-  "no-trailing-punctuation": false,
-  "ul-indent": false,
-  "no-inline-html": false
-}

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,14 +27,14 @@ theme:
 # Customization
 extra:
   social:
-  - type: 'github'
-    link: 'https://github.com/reanahub'
-  - type: 'twitter'
-    link: 'https://twitter.com/reanahub'
-  - type: 'comments'
-    link: 'https://forum.reana.io'
-  - type: 'globe'
-    link: 'http://www.reana.io'
+    - type: 'github'
+      link: 'https://github.com/reanahub'
+    - type: 'twitter'
+      link: 'https://twitter.com/reanahub'
+    - type: 'comments'
+      link: 'https://forum.reana.io'
+    - type: 'globe'
+      link: 'http://www.reana.io'
 extra_css:
   - stylesheets/extra.css
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -61,11 +61,16 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     docs_build
     lint_commitlint
     lint_docstyle
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -77,6 +82,7 @@ help() {
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-docstyle    Check linting of documentation"
     echo "  --lint-shellcheck  Check linting of shell scripts"
+    echo "  --lint-yamllint    Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -92,5 +98,6 @@ case $arg in
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-docstyle) lint_docstyle ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,6 +14,10 @@ docs_build() {
     rm -rf site/
 }
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -40,7 +44,7 @@ lint_commitlint() {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -67,6 +71,7 @@ lint_yamllint() {
 
 all() {
     docs_build
+    format_shfmt
     lint_commitlint
     lint_docstyle
     lint_shellcheck
@@ -78,6 +83,7 @@ help() {
     echo "Options:"
     echo "  --all              Perform all checks [default]"
     echo "  --docs-build       Check docs build"
+    echo "  --format-shfmt     Check formatting of shell scripts"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-docstyle    Check linting of documentation"
@@ -95,6 +101,7 @@ case $arg in
 --all) all ;;
 --help) help ;;
 --docs-build) docs_build ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-docstyle) lint_docstyle ;;
 --lint-shellcheck) lint_shellcheck ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -56,8 +56,11 @@ lint_commitlint() {
     fi
 }
 
-lint_docstyle() {
-    npx -p markdownlint-cli markdownlint docs/*
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
+lint_awesome_bot() {
     awesome_bot --allow-dupe --skip-save-results --allow-redirect docs/**/*.md
 }
 
@@ -72,8 +75,9 @@ lint_yamllint() {
 all() {
     docs_build
     format_shfmt
+    lint_awesome_bot
     lint_commitlint
-    lint_docstyle
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -81,14 +85,15 @@ all() {
 help() {
     echo "Usage: $0 [options]"
     echo "Options:"
-    echo "  --all              Perform all checks [default]"
-    echo "  --docs-build       Check docs build"
-    echo "  --format-shfmt     Check formatting of shell scripts"
-    echo "  --help             Display this help message"
-    echo "  --lint-commitlint  Check linting of commit messages"
-    echo "  --lint-docstyle    Check linting of documentation"
-    echo "  --lint-shellcheck  Check linting of shell scripts"
-    echo "  --lint-yamllint    Check linting of YAML files"
+    echo "  --all                Perform all checks [default]"
+    echo "  --docs-build         Check docs build"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-awesome-bot   Check linting of links in documentation"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-markdownlint  Check linting of Markdown documentation"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -102,8 +107,9 @@ case $arg in
 --help) help ;;
 --docs-build) docs_build ;;
 --format-shfmt) format_shfmt ;;
+--lint-awesome-bot) lint_awesome_bot ;;
 --lint-commitlint) lint_commitlint "$@" ;;
---lint-docstyle) lint_docstyle ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2024 CERN.
+# Copyright (C) 2019, 2020, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,20 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+docs_build() {
+    mkdocs build -v
+    rm -rf site/
+}
+
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -43,32 +52,45 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
-    find . -name "*.sh" -exec shellcheck {} \+
-}
-
-check_docstyle () {
+lint_docstyle() {
     npx -p markdownlint-cli markdownlint docs/*
     awesome_bot --allow-dupe --skip-save-results --allow-redirect docs/**/*.md
 }
 
-build_docs () {
-    mkdocs build -v
-    rm -rf site/
+lint_shellcheck() {
+    find . -name "*.sh" -exec shellcheck {} \+
+}
+
+all() {
+    docs_build
+    lint_commitlint
+    lint_docstyle
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all              Perform all checks [default]"
+    echo "  --docs-build       Check docs build"
+    echo "  --help             Display this help message"
+    echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-docstyle    Check linting of documentation"
+    echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_commitlint
-    check_shellcheck
-    check_docstyle
-    build_docs
+    all
+    exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    --check-docstyle) check_docstyle;;
-    --build-docs) build_docs;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--docs-build) docs_build ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-docstyle) lint_docstyle ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.